### PR TITLE
Issue 80 (Check if running environment supports colored output)

### DIFF
--- a/src/shared/environment/UnixoidEnvironment.php
+++ b/src/shared/environment/UnixoidEnvironment.php
@@ -49,7 +49,7 @@ class UnixoidEnvironment extends Environment {
 
         try {
             $tput      = $this->getPathToCommand('tput');
-            $exit_code = null;
+            $exit_code = -1;
             $result    = [];
             exec("{$tput} colors", $result, $exit_code);
             if (0 !== (int)$exit_code) {

--- a/src/shared/environment/UnixoidEnvironment.php
+++ b/src/shared/environment/UnixoidEnvironment.php
@@ -42,7 +42,7 @@ class UnixoidEnvironment extends Environment {
      */
     public function supportsColoredOutput() {
 
-        // Todo: Check the actual used output stream
+        // ConsoleOutput::writeText() uses STDOUT, too.
         if (! posix_isatty(STDOUT)) {
             return false;
         }

--- a/src/shared/environment/UnixoidEnvironment.php
+++ b/src/shared/environment/UnixoidEnvironment.php
@@ -52,7 +52,10 @@ class UnixoidEnvironment extends Environment {
             $exit_code = null;
             $result    = [];
             exec("{$tput} colors", $result, $exit_code);
-            if (0 === (int)$exit_code && isset($result[0]) && 8 === (int)$result[0]) {
+            if (0 !== (int)$exit_code) {
+                return false;
+            }
+            if (isset($result[0]) && 8 === (int)$result[0]) {
                 return true;
             }
         } catch (EnvironmentException $e) {}

--- a/src/shared/environment/UnixoidEnvironment.php
+++ b/src/shared/environment/UnixoidEnvironment.php
@@ -41,7 +41,23 @@ class UnixoidEnvironment extends Environment {
      * @return bool
      */
     public function supportsColoredOutput() {
-        return true;
+
+        // Todo: Check the actual used output stream
+        if (! posix_isatty(STDOUT)) {
+            return false;
+        }
+
+        try {
+            $tput      = $this->getPathToCommand('tput');
+            $exit_code = null;
+            $result    = [];
+            exec("{$tput} colors", $result, $exit_code);
+            if (0 === (int)$exit_code && isset($result[0]) && 8 === (int)$result[0]) {
+                return true;
+            }
+        } catch (EnvironmentException $e) {}
+
+        return false;
     }
 
     /**

--- a/tests/unit/shared/environment/EnvironmentTest.php
+++ b/tests/unit/shared/environment/EnvironmentTest.php
@@ -66,7 +66,9 @@ class UnixoidEnvironmentTest extends \PHPUnit_Framework_TestCase {
         $env->getHomeDirectory();
     }
 
+    public function testSupportsColoredOutput() {
+
+        $env = new UnixoidEnvironment([]);
+        $this->markTestIncomplete( 'Under construction' );
+    }
 }
-
-
-

--- a/tests/unit/shared/environment/EnvironmentTest.php
+++ b/tests/unit/shared/environment/EnvironmentTest.php
@@ -69,6 +69,9 @@ class UnixoidEnvironmentTest extends \PHPUnit_Framework_TestCase {
     public function testSupportsColoredOutput() {
 
         $env = new UnixoidEnvironment([]);
-        $this->markTestIncomplete( 'Under construction' );
+        $this->assertInternalType(
+            'bool',
+            $env->supportsColoredOutput()
+        );
     }
 }


### PR DESCRIPTION
A simple solution checking for `tput colors` according to [this answer](http://unix.stackexchange.com/a/9960/131049). I'm not sure how a sane unit test would look like that does not just duplicate the same logic, so the test actually checks for a proper return type. 