### PR TITLE
Fixing typo in key download success message

### DIFF
--- a/src/services/key/gpg/GnupgKeyDownloader.php
+++ b/src/services/key/gpg/GnupgKeyDownloader.php
@@ -59,7 +59,7 @@ class GnupgKeyDownloader implements KeyDownloader {
                 continue;
             }
 
-            $this->output->writeInfo('Sucessfully downloaded key');
+            $this->output->writeInfo('Successfully downloaded key');
 
             return new PublicKey($keyId, $keyInfo->getBody(), $publicKey->getBody());
         }


### PR DESCRIPTION
Just saw that on your slides in dresden ;)