### PR TITLE
Windows phar activator

### DIFF
--- a/src/shared/file/PharActivatorFactory.php
+++ b/src/shared/file/PharActivatorFactory.php
@@ -17,4 +17,12 @@ class PharActivatorFactory {
         return new SymlinkPharActivator();
     }
 
+
+    /**
+     * @return WindowsPharActivator
+     */
+    public function getWindowsPharActivator() {
+        return new WindowsPharActivator(file_get_contents(__DIR__ . '/../../../conf/pharBat.template'));
+    }
+
 }

--- a/src/shared/file/PharActivatorLocator.php
+++ b/src/shared/file/PharActivatorLocator.php
@@ -22,7 +22,7 @@ class PharActivatorLocator {
      */
     public function getPharActivator(Environment $environment) {
         if ($environment instanceof WindowsEnvironment) {
-            return $this->factory->getBatPharActivator();
+            return $this->factory->getWindowsPharActivator();
         }
 
         return $this->factory->getSymlinkPharActivator();

--- a/src/shared/file/WindowsPharActivator.php
+++ b/src/shared/file/WindowsPharActivator.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PharIo\Phive;
+
+use PharIo\FileSystem\Filename;
+
+/**
+ * The WindowsPharActivator tries to set a hardlink for the phar file.
+ * If that works it will add a bat file for the link, for
+ * the original phar file, otherwise.
+ */
+class WindowsPharActivator implements PharActivator {
+
+    const PHAR_PLACEHOLDER = '##PHAR_FILENAME##';
+
+    private $template;
+
+    /**
+     * @param string $template
+     */
+    public function __construct($template) {
+        $this->template = $template;
+    }
+
+    /**
+     * @param Filename $pharLocation
+     * @param Filename $linkDestination
+     *
+     * @return Filename
+     */
+    public function activate(Filename $pharLocation, Filename $linkDestination) {
+        $this->ensureDestinationIsWritable($linkDestination);
+
+        $destination = new Filename($linkDestination->asString().'.phar');
+        if ($this->addFileLink($pharLocation, $destination)) {
+            $template = str_replace(self::PHAR_PLACEHOLDER, $destination->asString(), $this->template);
+        } else {
+            $template = str_replace(self::PHAR_PLACEHOLDER, $pharLocation->asString(), $this->template);
+        }
+        $linkFilename = new Filename($linkDestination->asString().'.bat');
+        file_put_contents($linkFilename, $template);
+        return $destination;
+    }
+
+    /**
+     * Set a windows hardlink
+     *
+     * @param Filename $source
+     * @param Filename $target
+     * @return bool
+     */
+    private function addFileLink(Filename $source, Filename $target) {
+        $output = [];
+        $returnValue = 0;
+        exec(
+            'mklink /H '.escapeshellarg($source).' '.escapeshellarg($target),
+            $output,
+            $returnValue
+        );
+        return $returnValue === 0;
+    }
+
+    /**
+     * @param Filename $destination
+     *
+     * @throws FileNotWritableException
+     */
+    private function ensureDestinationIsWritable(Filename $destination) {
+        if (!$destination->getDirectory()->isWritable()) {
+            throw new FileNotWritableException(sprintf('File %s is not writable.', $destination->asString()));
+        }
+    }
+}

--- a/tests/unit/shared/file/PharActivatorLocatorTest.php
+++ b/tests/unit/shared/file/PharActivatorLocatorTest.php
@@ -31,7 +31,7 @@ class PharActivatorLocatorTest extends TestCase {
 
     public function returnsExpectedActivatorDataProvider() {
         return [
-            [$this->getWindowsEnvironmentMock(), 'getBatPharActivator'],
+            [$this->getWindowsEnvironmentMock(), 'getWindowsPharActivator'],
             [$this->getEnvironmentMock(), 'getSymlinkPharActivator']
         ];
     }

--- a/tests/unit/shared/file/WindowsPharActivatorTest.php
+++ b/tests/unit/shared/file/WindowsPharActivatorTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace PharIo\Phive;
+
+use PharIo\FileSystem\Filename;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PharIo\Phive\WindowsPharActivator
+ */
+class WindowsPharActivatorTest extends TestCase {
+
+    public function setUp() {
+        if (0 !== stripos(PHP_OS, 'win')) {
+            $this->markTestSkipped('OS is not Windows.');
+        }
+        $this->deleteTestFiles();
+    }
+
+    protected function tearDown() {
+        $this->deleteTestFiles();
+    }
+
+    public function testLinksPharAndCreatesExpectedBatFile() {
+        $testFile = __DIR__ . '/fixtures/some.phar';
+
+        $activator = new WindowsPharActivator('foo ##PHAR_FILENAME## bar');
+        $createdFile = $activator->activate(new Filename($testFile), new Filename('some'));
+        $createdBatchFile = preg_replace('(\.phar$)', '.bat', $createdFile);
+
+        $this->assertFileEquals($testFile, (string)$createdFile);
+        $this->assertEquals('foo %~dp0some.phar bar', file_get_contents($createdBatchFile));
+    }
+
+    private function deleteTestFiles() {
+        if (file_exists(__DIR__ . '/some.phar')) {
+            unlink(__DIR__ . '/some.phar');
+        }
+        if (file_exists(__DIR__ . '/some.bat')) {
+            unlink(__DIR__ . '/some.bat');
+        }
+    }
+}


### PR DESCRIPTION
An different approach for a Phar activator for Windows. It uses hard links to link the global Phar file into the tools directory and creates batch files to make them executable.

This allows the Phars to be available for other tools like PHPStorm and PHPUnit.