### PR TITLE
Clean else

### DIFF
--- a/tests/unit/TestStreamWrapper.php
+++ b/tests/unit/TestStreamWrapper.php
@@ -177,9 +177,9 @@ class TestStreamWrapper {
         // exist. This is consistent with PHP's plain filesystem stream wrapper.
         if ($flags & STREAM_URL_STAT_QUIET || !file_exists($translatedPath)) {
             return @stat($translatedPath);
-        } else {
-            return stat($translatedPath);
         }
+
+        return stat($translatedPath);
     }
 
 }


### PR DESCRIPTION
Small one: I've removed the `else` when we have already returned something :put_litter_in_its_place: