### PR TITLE
workaround to debian php version that does not use semver

### DIFF
--- a/src/services/phar/CompatibilityService.php
+++ b/src/services/phar/CompatibilityService.php
@@ -49,11 +49,12 @@ class CompatibilityService {
 
                 case $requirement instanceof PhpVersionRequirement: {
                     $php = $requirement->getVersionConstraint();
-                    if (!$php->complies(new Version(PHP_VERSION))) {
+                    $phpversion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+                    if (!$php->complies(new Version($phpversion))) {
                         $issues[] = sprintf(
                             'PHP Version %s required, but %s in use',
                             $php,
-                            PHP_VERSION
+                            $phpversion
                         );
                     }
                     continue 2;

--- a/src/services/phar/CompatibilityService.php
+++ b/src/services/phar/CompatibilityService.php
@@ -49,12 +49,16 @@ class CompatibilityService {
 
                 case $requirement instanceof PhpVersionRequirement: {
                     $php = $requirement->getVersionConstraint();
-                    $phpversion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
-                    if (!$php->complies(new Version($phpversion))) {
+                    try {
+                        $phpversion = new Version(PHP_VERSION);
+                    } catch (InvalidVersionException $ex) {
+                        $phpversion = new Version(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION);
+                    }
+                    if (!$php->complies($phpversion)) {
                         $issues[] = sprintf(
                             'PHP Version %s required, but %s in use',
                             $php,
-                            $phpversion
+                            PHP_VERSION
                         );
                     }
                     continue 2;

--- a/src/shared/environment/Environment.php
+++ b/src/shared/environment/Environment.php
@@ -131,7 +131,7 @@ abstract class Environment {
             return HHVM_VERSION;
         }
 
-        return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+        return PHP_VERSION;
     }
 
     /**

--- a/src/shared/environment/Environment.php
+++ b/src/shared/environment/Environment.php
@@ -131,7 +131,7 @@ abstract class Environment {
             return HHVM_VERSION;
         }
 
-        return PHP_VERSION;
+        return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
     }
 
     /**


### PR DESCRIPTION
Debian is using a version that is breaking SemVer (example `7.0.29-1`)
This is on `PHP_VERSION` constant, but as workaround the php version can be built from constants `PHP_MAJOR_VERSION`, `PHP_MINOR_VERSION` & `PHP_RELEASE_VERSION`

This PR uses this concatenation strategy on `PharIo\Phive\CompatibilityService::canRun` and `\PharIo\Phive\Environment::getRuntimeVersion`.

This would also fix #136
Related: phar-io/version#10