### PR TITLE
Fix typos in documentation/output/help text

### DIFF
--- a/concept.md
+++ b/concept.md
@@ -31,7 +31,7 @@
 - remove 
 
 - sync
-    - compare current state with phive.xml defintion and latest versions
+    - compare current state with phive.xml definition and latest versions
         - act accordingly
 
 - update 

--- a/src/commands/help/help.txt
+++ b/src/commands/help/help.txt
@@ -25,7 +25,7 @@ install [--target bin/] <alias|url> [<alias|url> ...]
     -c, --copy            Copy PHAR file instead of using symlink
     -g, --global          Install a copy of the PHAR globally (likely to require root privileges)
         --temporary       Do not add entries in phive.xml for installed PHARs
-        --trust-gpg-keys  Silently import these keys when required (multiple keys can be seperated by comma)
+        --trust-gpg-keys  Silently import these keys when required (multiple keys can be separated by comma)
 
 composer
     Parse composer.json file for known aliases and suggest installation

--- a/src/shared/sources/RemoteSourcesListFileLoader.php
+++ b/src/shared/sources/RemoteSourcesListFileLoader.php
@@ -72,7 +72,7 @@ class RemoteSourcesListFileLoader implements SourcesListFileLoader {
      * @throws DownloadFailedException
      */
     public function downloadFromSource() {
-        $this->output->writeInfo('Fetching respository list');
+        $this->output->writeInfo('Fetching repository list');
         $file = $this->fileDownloader->download($this->sourceUrl);
         $file->saveAs($this->filename);
     }


### PR DESCRIPTION
These were detected by https://github.com/client9/misspell