### PR TITLE
Fix composer warning about package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "phar-io/manifest": "^1.0"
   },
   "require-dev": {
-    "mikey179/vfsStream": "^1.6.4"
+    "mikey179/vfsstream": "^1.6.4"
   },
   "suggest": {
     "ext-gnupg": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c4829aa5322f0fa85abea0361075251",
+    "content-hash": "8f64c262bfd34938fcd0c2a095ca2274",
     "packages": [
         {
             "name": "phar-io/executor",


### PR DESCRIPTION
Composer 2.0 will error when package names contain upper case characters.