### PR TITLE
setup first github action steps

### DIFF
--- a/.github/actions/phive-ant/Dockerfile
+++ b/.github/actions/phive-ant/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:buster
+
+RUN apt update \
+    && apt-get install -y --no-install-recommends ant php-cli php-dom php-curl php-mbstring wget gpg dirmngr gpg-agent
+
+ENTRYPOINT ["ant"]

--- a/.github/actions/phive-ant/action.yml
+++ b/.github/actions/phive-ant/action.yml
@@ -1,0 +1,12 @@
+name: 'Phive ant'
+description: 'Ant wrapper for phive in github actions'
+inputs:
+  target:  # id of input
+    description: 'Ant target to execute'
+    required: true
+    default: 'build'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.target }}

--- a/.github/actions/phive-ant/action.yml
+++ b/.github/actions/phive-ant/action.yml
@@ -3,7 +3,7 @@ description: 'Ant wrapper for phive in github actions'
 inputs:
   target:  # id of input
     description: 'Ant target to execute'
-    required: true
+    required: false
     default: 'build'
 runs:
   using: 'docker'

--- a/.github/actions/phive-ant/action.yml
+++ b/.github/actions/phive-ant/action.yml
@@ -1,12 +1,5 @@
 name: 'Phive ant'
 description: 'Ant wrapper for phive in github actions'
-inputs:
-  target:  # id of input
-    description: 'Ant target to execute'
-    required: false
-    default: 'build'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Code quallity checks
+# This workflow is triggered on pushes to the repository.
+on: [push]
+
+jobs:
+  qa:
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: composer
+        uses: docker://composer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: install --no-interaction --prefer-dist --optimize-autoloader
+      - name: phive
+        uses: './.github/actions/phive-ant'
+        with:
+          target: 'getphive'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: phive
         uses: './.github/actions/phive-ant'
         with:
-          target: 'getphive'
+          args: 'getphive'
 
       - name: php-cs-fixer
         uses: './.github/actions/phive-ant'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           phive.bin: "/phive.phar"
         with:
-          args: install-tools php-cs-fixer
+          args: -Dphive.bin=./phive.phar install-tools php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           phive.bin: "/phive.phar"
         with:
-          target: install-tools php-cs-fixer
+          args: install-tools php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: install --no-interaction --prefer-dist --optimize-autoloader
+
       - name: phive
         uses: './.github/actions/phive-ant'
         with:
           target: 'getphive'
 
+      - name: php-cs-fixer
+        uses: './.github/actions/phive-ant'
+        env:
+          phive.bin: "/phive.phar"
+        with:
+          target: install-tools php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,16 @@ jobs:
         with:
           args: 'getphive'
 
+      - name: phive install
+        uses: './.github/actions/phive-ant'
+        env:
+          phive.bin: "/phive.phar"
+        with:
+          args: -Dphive.bin=./phive.phar install-tools
+
       - name: php-cs-fixer
         uses: './.github/actions/phive-ant'
         env:
           phive.bin: "/phive.phar"
         with:
-          args: -Dphive.bin=./phive.phar install-tools php-cs-fixer
+          args: -Dphive.bin=./phive.phar php-cs-fixer

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Phive" default="build" basedir=".">
     <property name="source" value="src"/>
+    <property name="phive.bin" value="phive"/>
 
     <target name="setup" depends="clean,composer,install-tools,generate-autoloader"/>
     <target name="build" depends="setup,lint,test"/>
@@ -65,12 +66,11 @@
     </target>
 
     <target name="install-tools" unless="tools-installed" depends="-tools-installed" description="Install tools with Phive">
-        <exec executable="phive" taskname="phive">
+        <exec executable="${phive.bin}" taskname="phive">
             <arg value="install"/>
             <arg value="--trust-gpg-keys" />
-            <arg value="4AA394086372C20A,2A8299CE842DD38C" />
-            <arg value="phpab" />
-            <arg value="phpunit@^8.0" />
+            <!--        phpab,           phpunit,         phpstan,         psaml,           php-cs-fixer     -->
+            <arg value="4AA394086372C20A,2A8299CE842DD38C,8E730BA25823D8B5,8A03EA3B385DBAA1,E82B2FB314E9906E" />
         </exec>
     </target>
 
@@ -148,5 +148,11 @@
         </exec>
     </target>
 
+    <target name="php-cs-fixer" description="Dry run php csfixer">
+        <exec executable="./tools/php-cs-fixer" failonerror="true">
+            <arg value="fix" />
+            <arg value="--dry-run" />
+        </exec>
+    </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -68,6 +68,7 @@
     <target name="install-tools" unless="tools-installed" depends="-tools-installed" description="Install tools with Phive">
         <exec executable="${phive.bin}" taskname="phive">
             <arg value="install"/>
+            <arg value="--copy" />
             <arg value="--trust-gpg-keys" />
             <!--        phpab,           phpunit,         phpstan,         psaml,           php-cs-fixer     -->
             <arg value="4AA394086372C20A,2A8299CE842DD38C,8E730BA25823D8B5,8A03EA3B385DBAA1,E82B2FB314E9906E" />


### PR DESCRIPTION
I added a new Github action in `./github/actions/phive-ant` which contains all packages required to run the `ant` setup in this project. This allowed me to define ant tasks that you are familiar with to execute the actions. 

A number of things could be improved:

- One problem I'm currently facing it the installation of tools by phive. The tools are symlinked in a docker container for that specific action. So after the action step is finished the tools are gone. only the symlinks are still there. 

- output of phive install is very verbose. Can we disable the progress bars of the downloads someway?