### PR TITLE
Fix #217: Hard dependency on `which` command

### DIFF
--- a/build/phpstan/bootstrap.php
+++ b/build/phpstan/bootstrap.php
@@ -10,32 +10,43 @@ class Gnupg {
     }
 }
 
-/**
- * @template-covariant TNode as DomElement
- * @template-implements Traversable<int, TNode>
- */
-class DOMNodeList implements Traversable, Countable {
+if (!class_exists('DOMNodeList')) {
     /**
-     * @var int
-     *
-     * @since 5.0
-     * The number of nodes in the list. The range of valid child node indices is 0 to length - 1 inclusive.
-     * @link http://php.net/manual/en/class.domnodelist.php#domnodelist.props.length
+     * @template-covariant  TNode as DomElement
+     * @template-implements Traversable<int, TNode>
      */
-    public $length;
+    class DOMNodeList implements Traversable, Countable
+    {
 
-    public function item($index): void {
+        /**
+         * @var int
+         *
+         * @since 5.0
+         * The number of nodes in the list. The range of valid child node indices is 0 to length - 1 inclusive.
+         * @link  http://php.net/manual/en/class.domnodelist.php#domnodelist.props.length
+         */
+        public $length;
+
+        /**
+         * @return TNode|null
+         */
+        public function item($index): void {
+        }
     }
 }
 
-/**
- * @return resource
- */
-function curl_init(?string $url) {
+if (!function_exists('curl_init')) {
+    /**
+     * @return resource
+     */
+    function curl_init(?string $url) {
+    }
 }
 
-/**
- * @param resource $handle
- */
-function curl_exec($handle): string {
+if (!function_exists('curl_exec')) {
+    /**
+     * @param resource $handle
+     */
+    function curl_exec($handle): string {
+    }
 }

--- a/src/shared/environment/Environment.php
+++ b/src/shared/environment/Environment.php
@@ -24,7 +24,7 @@ abstract class Environment {
      * @throws EnvironmentException
      */
     public function getPathToCommand(string $command): Filename {
-        $result = \exec(\sprintf('%s %s', $this->getWhichCommand(), $command), $output, $exitCode);
+        $result = \exec(\sprintf('%s %s', $this->getWhichCommand(), \escapeshellarg($command)), $output, $exitCode);
 
         if ($exitCode !== 0) {
             throw new EnvironmentException(\sprintf('Command %s not found', $command));


### PR DESCRIPTION
- Try several commands to find command path
- Run PHP-CS-Fixer + PHPStan + Psalm on `src/shared/environment/`

----

PHPStan complain about `new static()`, but I not sure about what to do to solve it. (Ignoring the error? Hard-code the class name ? Etc.)