### PR TITLE
Add GitLab as an alias resolver

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -257,6 +257,12 @@ class Factory {
         );
     }
 
+    public function getGitlabAliasResolver(): GitlabAliasResolver {
+        return new GitlabAliasResolver(
+            $this->getFileDownloader()
+        );
+    }
+
     private function getTargetDirectoryLocator(): TargetDirectoryLocator {
         return new TargetDirectoryLocator(
             $this->getConfig(),

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -9,6 +9,7 @@ spl_autoload_register(
             $classes = array(
                 'phario\\phive\\abstractrequestedpharresolver' => '/services/resolver/AbstractRequestedPharResolver.php',
                 'phario\\phive\\abstractresolvingstrategy' => '/services/resolver/strategy/AbstractResolvingStrategy.php',
+                'phario\\phive\\authentication' => '/shared/http/Authentication.php',
                 'phario\\phive\\basehash' => '/shared/hash/BaseHash.php',
                 'phario\\phive\\cachebackend' => '/shared/http/CacheBackend.php',
                 'phario\\phive\\checksumservice' => '/services/checksum/ChecksumService.php',
@@ -75,6 +76,8 @@ spl_autoload_register(
                 'phario\\phive\\githubaliasresolverexception' => '/GithubAliasResolverException.php',
                 'phario\\phive\\githubrepository' => '/shared/repository/GithubRepository.php',
                 'phario\\phive\\githubversion' => '/shared/version/GitHubVersion.php',
+                'phario\\phive\\gitlabaliasresolver' => '/services/resolver/GitlabAliasResolver.php',
+                'phario\\phive\\gitlabrepository' => '/shared/repository/GitlabRepository.php',
                 'phario\\phive\\globalphivexmlconfig' => '/shared/config/GlobalPhiveXmlConfig.php',
                 'phario\\phive\\gnupgkeydownloader' => '/services/key/gpg/GnupgKeyDownloader.php',
                 'phario\\phive\\gnupgkeydownloaderexception' => '/shared/exceptions/GnupgKeyDownloaderException.php',

--- a/src/commands/help/help.md
+++ b/src/commands/help/help.md
@@ -19,8 +19,8 @@
 **install [--target bin/] <alias|url> [<alias|url> ...]**
     Perform installation of a phar distributed application or library
 
-    _alias/url_                    Installation via github profile/project, phar.io alias
-                                 or explicit download form given URL
+    _alias/url_                    Installation via github profile/project, gitlab profile/project,
+                                 phar.io alias or explicit download form given URL
 
     _-t, --target_                 Set custom target directory for the PHAR
 

--- a/src/services/resolver/GitlabAliasResolver.php
+++ b/src/services/resolver/GitlabAliasResolver.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+class GitlabAliasResolver extends AbstractRequestedPharResolver {
+    /** @var FileDownloader */
+    private $fileDownloader;
+
+    public function __construct(FileDownloader $fileDownloader) {
+        $this->fileDownloader = $fileDownloader;
+    }
+
+    public function resolve(RequestedPhar $requestedPhar): SourceRepository {
+        if (!$requestedPhar->hasAlias()) {
+            return $this->tryNext($requestedPhar);
+        }
+
+        $name = $requestedPhar->getAlias()->asString();
+
+        if (\strpos($name, '/') === false) {
+            return $this->tryNext($requestedPhar);
+        }
+
+        try {
+            return $this->localResolve($name);
+        } catch (DownloadFailedException $e) {
+            return $this->tryNext($requestedPhar);
+        }
+    }
+
+    private function localResolve(string $name): GitlabRepository {
+        [$username, $project] = \explode('/', $name);
+        $url                  = new Url(
+            \sprintf('https://gitlab.com/api/v4/projects/%s%%2F%s/releases/', $username, $project)
+        );
+
+        $file = $this->fileDownloader->download($url);
+
+        return new GitlabRepository(
+            new JsonData($file->getContent())
+        );
+    }
+}

--- a/src/services/resolver/PharIoAliasResolver.php
+++ b/src/services/resolver/PharIoAliasResolver.php
@@ -38,6 +38,10 @@ class PharIoAliasResolver extends AbstractRequestedPharResolver {
                 return new GithubRepository(
                     new JsonData($file->getContent())
                 );
+            case 'gitlab':
+                return new GitlabRepository(
+                    new JsonData($file->getContent())
+                );
             case 'phar.io':
                 $filename = new Filename(\tempnam(\sys_get_temp_dir(), 'repo_'));
                 $file->saveAs($filename);

--- a/src/services/resolver/RequestedPharResolverFactory.php
+++ b/src/services/resolver/RequestedPharResolverFactory.php
@@ -32,6 +32,10 @@ class RequestedPharResolverFactory {
         return $this->factory->getGithubAliasResolver();
     }
 
+    public function getGitlabAliasResolver(): GitlabAliasResolver {
+        return $this->factory->getGitlabAliasResolver();
+    }
+
     public function getLocalSourcesListFileLoader(): LocalSourcesListFileLoader {
         return new LocalSourcesListFileLoader(
             $this->factory->getConfig()->getHomeDirectory()->file('local.xml')

--- a/src/services/resolver/strategy/AbstractResolvingStrategy.php
+++ b/src/services/resolver/strategy/AbstractResolvingStrategy.php
@@ -13,6 +13,9 @@ class AbstractResolvingStrategy implements ResolvingStrategy {
         // github.com
         $service->addResolver($this->factory->getGithubAliasResolver());
 
+        // gitlab.com
+        $service->addResolver($this->factory->getGitlabAliasResolver());
+
         // local repository XML
         $service->addResolver(
             $this->factory->getPharIoAliasResolver($this->factory->getLocalSourcesListFileLoader())

--- a/src/shared/environment/Environment.php
+++ b/src/shared/environment/Environment.php
@@ -56,6 +56,20 @@ abstract class Environment {
         return \array_key_exists('https_proxy', $this->server);
     }
 
+    public function getAuthentications(): array {
+        $authList = [];
+
+        if ($this->hasGitHubAuthToken()) {
+            $authList[] = new Authentication('api.github.com', Authentication::TYPE_TOKEN, $this->getGitHubAuthToken());
+        }
+
+        if (\array_key_exists('GITLAB_AUTH_TOKEN', $this->server)) {
+            $authList[] = new Authentication('gitlab.com', Authentication::TYPE_BEARER, $this->server['GITLAB_AUTH_TOKEN']);
+        }
+
+        return $authList;
+    }
+
     public function hasGitHubAuthToken(): bool {
         return \array_key_exists('GITHUB_AUTH_TOKEN', $this->server);
     }

--- a/src/shared/http/Authentication.php
+++ b/src/shared/http/Authentication.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+class Authentication {
+    public const TYPE_TOKEN  = 'Token';
+    public const TYPE_BEARER = 'Bearer';
+    public const TYPE_BASIC  = 'Basic';
+    public const TYPE_DIGEST = 'Digest';
+
+    /** @var string */
+    private $type;
+    /** @var string */
+    private $credentials;
+    /** @var string */
+    private $domain;
+
+    public static function fromLoginPassword(string $domain, string $login, string $password): Authentication {
+        $credentials = \base64_encode($login . ':' . $password);
+
+        return new static($domain, self::TYPE_BASIC, $credentials);
+    }
+
+    public function __construct(string $domain, string $type, string $credentials) {
+        $this->type        = $type;
+        $this->credentials = $credentials;
+        $this->domain      = $domain;
+    }
+
+    public function asString(): string {
+        return \sprintf('Authorization: %s %s', $this->type, $this->credentials);
+    }
+
+    public function getDomain(): string {
+        return $this->domain;
+    }
+}

--- a/src/shared/http/CurlConfig.php
+++ b/src/shared/http/CurlConfig.php
@@ -80,12 +80,14 @@ class CurlConfig {
     /**
      * @throws CurlConfigException
      */
-    public function addAuthenticationToken(string $hostname, string $token): void {
+    public function addAuthenticationToken(Authentication $authentication): void {
+        $hostname = $authentication->getDomain();
+
         if ($this->hasAuthenticationToken($hostname)) {
             throw new CurlConfigException(\sprintf('Authentication token for hostname %s already set', $hostname));
         }
 
-        $this->authenticationTokens[$hostname] = $token;
+        $this->authenticationTokens[$hostname] = $authentication;
     }
 
     public function hasAuthenticationToken(string $hostname): bool {
@@ -95,7 +97,7 @@ class CurlConfig {
     /**
      * @throws CurlConfigException
      */
-    public function getAuthenticationToken(string $hostname): string {
+    public function getAuthenticationToken(string $hostname): Authentication {
         if (!$this->hasAuthenticationToken($hostname)) {
             throw new CurlConfigException(\sprintf('No authentication for hostname %s found', $hostname));
         }

--- a/src/shared/http/CurlConfigBuilder.php
+++ b/src/shared/http/CurlConfigBuilder.php
@@ -33,11 +33,8 @@ class CurlConfigBuilder {
             $curlConfig->setProxy($this->environment->getProxy());
         }
 
-        if ($this->environment->hasGitHubAuthToken()) {
-            $curlConfig->addAuthenticationToken(
-                'api.github.com',
-                $this->environment->getGitHubAuthToken()
-            );
+        foreach ($this->environment->getAuthentications() as $authentication) {
+            $curlConfig->addAuthenticationToken($authentication);
         }
 
         return $curlConfig;

--- a/src/shared/http/CurlHttpClient.php
+++ b/src/shared/http/CurlHttpClient.php
@@ -116,7 +116,7 @@ class CurlHttpClient implements HttpClient {
         }
 
         if ($this->config->hasAuthenticationToken($hostname)) {
-            $headers[] = \sprintf('Authorization: token %s', $this->config->getAuthenticationToken($hostname));
+            $headers[] = $this->config->getAuthenticationToken($hostname)->asString();
         }
 
         if (\count($headers) > 0) {

--- a/src/shared/repository/GitlabRepository.php
+++ b/src/shared/repository/GitlabRepository.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+use PharIo\Version\InvalidVersionException;
+
+class GitlabRepository implements SourceRepository {
+
+    /** @var JsonData */
+    private $jsonData;
+
+    public function __construct(JsonData $json) {
+        $this->jsonData = $json;
+    }
+
+    public function getReleasesByRequestedPhar(RequestedPhar $requestedPhar): ReleaseCollection {
+        $releases = new ReleaseCollection();
+        $name     = $requestedPhar->getAlias()->asString();
+
+        foreach ($this->jsonData->getParsed() as $entry) {
+            try {
+                $version = new GitHubVersion($entry->tag_name);
+            } catch (InvalidVersionException $exception) {
+                // we silently ignore invalid version identifiers for now as they are
+                // likely to be an arbitrary tag that erroneously got promoted to release
+                continue;
+            }
+            $pharUrl      = null;
+            $signatureUrl = null;
+
+            foreach ($entry->assets->links as $asset) {
+                $assetName = $asset->name;
+                $url       = $asset->url;
+
+                if (\substr($assetName, -5, 5) === '.phar') {
+                    $pharUrl = new PharUrl($url);
+
+                    continue;
+                }
+
+                if (\in_array(\substr($assetName, -4, 4), ['.asc', '.sig'], true)) {
+                    $signatureUrl = new Url($url);
+                }
+            }
+
+            // we do seem to have a version but no phar asset - can't use?
+            if (!$pharUrl instanceof Url) {
+                $releases->add(
+                    new UnsupportedRelease($name, $version, 'No downloadable PHAR')
+                );
+
+                continue;
+            }
+
+            // we do have a phar but no signature, could potentially be used
+            if (!$signatureUrl instanceof Url) {
+                $releases->add(
+                    new SupportedRelease($name, $version, $pharUrl)
+                );
+
+                continue;
+            }
+
+            $releases->add(
+                // Gitlab doesn't publish any hashes for the files :-(
+                new SupportedRelease($name, $version, $pharUrl, $signatureUrl)
+            );
+        }
+
+        return $releases;
+    }
+}

--- a/src/shared/sources/Source.php
+++ b/src/shared/sources/Source.php
@@ -24,7 +24,7 @@ class Source {
     }
 
     private function ensureValidSourceType(string $type): void {
-        if (!\in_array($type, ['phar.io', 'github'])) {
+        if (!\in_array($type, ['phar.io', 'github', 'gitlab'])) {
             throw new \InvalidArgumentException(
                 \sprintf('Unsupported source repository type "%s"', $type)
             );

--- a/tests/unit/services/key/gpg/GnupgKeyDownloaderTest.php
+++ b/tests/unit/services/key/gpg/GnupgKeyDownloaderTest.php
@@ -4,6 +4,9 @@ namespace PharIo\Phive;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 
+/**
+ * @covers \PharIo\Phive\GnupgKeyDownloader
+ */
 class GnupgKeyDownloaderTest extends TestCase {
     /** @var CurlHttpClient|ObjectProphecy */
     private $curl;

--- a/tests/unit/services/key/gpg/GnupgKeyImporterTest.php
+++ b/tests/unit/services/key/gpg/GnupgKeyImporterTest.php
@@ -3,6 +3,9 @@ namespace PharIo\Phive;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \PharIo\Phive\GnupgKeyImporter
+ */
 class GnupgKeyImporterTest extends TestCase {
     public function testImport(): void {
         $gnupg = $this->prophesize(\Gnupg::class);

--- a/tests/unit/shared/environment/EnvironmentLocatorTest.php
+++ b/tests/unit/shared/environment/EnvironmentLocatorTest.php
@@ -3,6 +3,9 @@ namespace PharIo\Phive;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \PharIo\Phive\EnvironmentLocator
+ */
 class EnvironmentLocatorTest extends TestCase {
     /**
      * @dataProvider osProvider

--- a/tests/unit/shared/environment/UnixoidEnvironmentTest.php
+++ b/tests/unit/shared/environment/UnixoidEnvironmentTest.php
@@ -111,6 +111,20 @@ class UnixoidEnvironmentTest extends TestCase {
         $environment->getGitHubAuthToken();
     }
 
+    public function testGetAuthentications(): void {
+        $environment = new UnixoidEnvironment([], $this->getExecutorMock());
+        $this->assertCount(0, $environment->getAuthentications());
+
+        $environment = new UnixoidEnvironment(['GITHUB_AUTH_TOKEN' => 'foo'], $this->getExecutorMock());
+        $this->assertCount(1, $environment->getAuthentications());
+
+        $environment = new UnixoidEnvironment(
+            ['GITHUB_AUTH_TOKEN' => 'foo', 'GITLAB_AUTH_TOKEN' => 'bar'],
+            $this->getExecutorMock()
+        );
+        $this->assertCount(2, $environment->getAuthentications());
+    }
+
     /**
      * @return Executor|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/tests/unit/shared/http/AuthenticationTest.php
+++ b/tests/unit/shared/http/AuthenticationTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+namespace unit\shared\http;
+
+use PharIo\Phive\Authentication;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PharIo\Phive\Authentication
+ */
+class AuthenticationTest extends TestCase {
+    public function testCanBeConvertedToString(): void {
+        $this->assertEquals(
+            'Authorization: Bearer foo',
+            (new Authentication('example.com', Authentication::TYPE_BEARER, 'foo'))->asString()
+        );
+    }
+
+    public function testFromLoginPassword(): void {
+        // https://tools.ietf.org/html/rfc7617#section-2
+        $this->assertEquals(
+            'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+            Authentication::fromLoginPassword('example.com', 'Aladdin', 'open sesame')->asString()
+        );
+    }
+}

--- a/tests/unit/shared/http/CurlConfigBuilderTest.php
+++ b/tests/unit/shared/http/CurlConfigBuilderTest.php
@@ -45,14 +45,21 @@ class CurlConfigBuilderTest extends TestCase {
     }
 
     public function testAddsGitHubAuthToken(): void {
-        $this->environment->method('hasGitHubAuthToken')
-            ->willReturn(true);
-        $this->environment->method('getGitHubAuthToken')
-            ->willReturn('foo');
+        $this->environment->method('getAuthentications')
+            ->willReturn([new Authentication('api.github.com', 'token', 'foo')]);
 
         $config = $this->builder->build();
         $this->assertTrue($config->hasAuthenticationToken('api.github.com'));
-        $this->assertSame('foo', $config->getAuthenticationToken('api.github.com'));
+        $this->assertSame('Authorization: token foo', $config->getAuthenticationToken('api.github.com')->asString());
+    }
+
+    public function testAddsGitLabAuthToken(): void {
+        $this->environment->method('getAuthentications')
+            ->willReturn([new Authentication('gitlab.com', 'bearer', 'foo')]);
+
+        $config = $this->builder->build();
+        $this->assertTrue($config->hasAuthenticationToken('gitlab.com'));
+        $this->assertSame('Authorization: bearer foo', $config->getAuthenticationToken('gitlab.com')->asString());
     }
 
     /**

--- a/tests/unit/shared/http/CurlHttpClientTest.php
+++ b/tests/unit/shared/http/CurlHttpClientTest.php
@@ -201,7 +201,7 @@ class CurlHttpClientTest extends TestCase {
 
         $this->curlConfig->method('getAuthenticationToken')
             ->with('example.com')
-            ->willReturn('foobar');
+            ->willReturn(new Authentication('example.com', 'token', 'foobar'));
 
         $this->curl->expects($this->once())
             ->method('addHttpHeaders')

--- a/tests/unit/shared/repository/GitlabRepositoryTest.php
+++ b/tests/unit/shared/repository/GitlabRepositoryTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PharIo\Phive\GitlabRepository
+ */
+class GitlabRepositoryTest extends TestCase {
+    public function testReturnsExpectedReleases(): void {
+        $pharAlias = $this->getPharAliasMock();
+        $pharAlias->method('asString')->willReturn('foo');
+
+        $requestedPhar = $this->getRequestedPharMock();
+        $requestedPhar->method('getAlias')->willReturn($pharAlias);
+
+        $entry1 = $this->getGitlabEntry('5.3.0', 'https://example.com/foo-5.3.0.phar');
+        $entry2 = $this->getGitlabEntry('5.2.11', 'https://example.com/broken');
+        $entry3 = $this->getGitlabEntry('5.2.12', 'https://example.com/foo-5.2.12.phar');
+
+        $jsonData = $this->getJsonDataMock();
+        $jsonData->method('getParsed')
+            ->willReturn([$entry1, $entry2, $entry3]);
+
+        $expectedReleases = new ReleaseCollection();
+        $expectedReleases->add(
+            new SupportedRelease(
+                'foo',
+                new GitHubVersion('5.3.0'),
+                new PharUrl('https://example.com/foo-5.3.0.phar'),
+                new Url('https://example.com/foo-5.3.0.phar.asc')
+            )
+        );
+        $expectedReleases->add(
+            new UnSupportedRelease(
+                'foo',
+                new GitHubVersion('5.2.11'),
+                'No downloadable PHAR'
+            )
+        );
+        $expectedReleases->add(
+            new SupportedRelease(
+                'foo',
+                new GitHubVersion('5.2.12'),
+                new PharUrl('https://example.com/foo-5.2.12.phar'),
+                new Url('https://example.com/foo-5.2.12.phar.asc')
+            )
+        );
+
+        $repository = new GitlabRepository($jsonData);
+        $this->assertEquals(
+            $expectedReleases,
+            $repository->getReleasesByRequestedPhar($requestedPhar)
+        );
+    }
+
+    /**
+     * @param string $version
+     * @param string $url
+     */
+    private function getGitlabEntry($version, $url): \stdClass {
+        $asset       = new \stdClass();
+        $asset->url  = $url;
+        $asset->name = \basename($url);
+
+        $sig       = new \stdClass();
+        $sig->url  = $url . '.asc';
+        $sig->name = \basename($url) . '.asc';
+
+        $assets        = new \stdClass();
+        $assets->links = [$asset, $sig];
+
+        $entry           = new \stdClass();
+        $entry->tag_name = $version;
+        $entry->assets   = $assets;
+
+        return $entry;
+    }
+
+    /**
+     * @return JsonData|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getJsonDataMock() {
+        return $this->createMock(JsonData::class);
+    }
+
+    /**
+     * @return PharAlias|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPharAliasMock() {
+        return $this->createMock(PharAlias::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|RequestedPhar
+     */
+    private function getRequestedPharMock() {
+        return $this->createMock(RequestedPhar::class);
+    }
+}

--- a/tests/unit/shared/version/GitHubVersionTest.php
+++ b/tests/unit/shared/version/GitHubVersionTest.php
@@ -4,6 +4,9 @@ namespace PharIo\Phive;
 use PharIo\Version\VersionNumber;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \PharIo\Phive\GitHubVersion
+ */
 class GitHubVersionTest extends TestCase {
     /**
      * @dataProvider versionPrefixProvider


### PR DESCRIPTION
 - Add Gitlab Alias resolver (same as Github)
 - Add new resolver in alias strategy
 - Refactor HTTP authentication
 - Fix `@covers` annotation missing on some tests

----

Gitlab repository used during E2E test: https://gitlab.com/MacFJA/phive-demo-tmp (I will remove it after this PR is closed)