### PR TITLE
Fix #218: Error when we are unable to read CLI input

### DIFF
--- a/src/shared/cli/input/ConsoleInput.php
+++ b/src/shared/cli/input/ConsoleInput.php
@@ -27,7 +27,13 @@ class ConsoleInput implements Input {
 
         do {
             $this->output->writeText(\rtrim($message) . \sprintf(' [%s|%s] ', $yesOption, $noOption));
-            $response = \strtolower(\rtrim(\fgets($this->inputStream)));
+            $input = \fgets($this->inputStream);
+
+            if ($input === false) {
+                throw new RunnerException('Needs tty to be able to confirm');
+            }
+
+            $response = \strtolower(\rtrim($input));
         } while (!\in_array($response, ['y', 'n', ''], true));
 
         if ($response === '') {

--- a/tests/unit/shared/cli/ConsoleInputTest.php
+++ b/tests/unit/shared/cli/ConsoleInputTest.php
@@ -3,6 +3,7 @@ namespace PharIo\Phive;
 
 use PharIo\Phive\Cli\ConsoleInput;
 use PharIo\Phive\Cli\Output;
+use PharIo\Phive\Cli\RunnerException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -84,6 +85,27 @@ class ConsoleInputTest extends TestCase {
 
         $input = new ConsoleInput($output, $inputStream);
         $this->assertSame($default, $input->confirm('foo?', $default));
+    }
+
+    public function testOnNonInteractive(): void {
+        $output = $this->getOutputMock();
+        $output->expects($this->once())
+            ->method('writeText')
+            ->with('foo? [Y|n] ');
+
+        /*
+         * Emulate a non-interactive shell by not writing anything
+         *
+         * In a real shell it can be emulate with `echo -n | phive install ...`
+         */
+        $inputStream = \fopen('php://memory', 'r');
+
+        $input = new ConsoleInput($output, $inputStream);
+
+        $this->expectException(RunnerException::class);
+        $this->expectExceptionMessage('Needs tty to be able to confirm');
+
+        $input->confirm('foo?');
     }
 
     /**


### PR DESCRIPTION
Add protection for non-interactive shell (or any error from fgets)