### PR TITLE
Add partial help

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -43,7 +43,8 @@ class Factory {
     public function getHelpCommand(): HelpCommand {
         return new HelpCommand(
             $this->getEnvironment(),
-            $this->getOutput()
+            $this->getOutput(),
+            new HelpCommandConfig($this->request->parse(new HelpContext()))
         );
     }
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -94,6 +94,8 @@ spl_autoload_register(
                 'phario\\phive\\gnupgverificationresult' => '/services/signature/gpg/GnupgVerificationResult.php',
                 'phario\\phive\\hash' => '/shared/hash/Hash.php',
                 'phario\\phive\\helpcommand' => '/commands/help/HelpCommand.php',
+                'phario\\phive\\helpcommandconfig' => '/commands/help/HelpCommandConfig.php',
+                'phario\\phive\\helpcontext' => '/commands/help/HelpContext.php',
                 'phario\\phive\\httpclient' => '/shared/http/HttpClient.php',
                 'phario\\phive\\httpexception' => '/shared/http/HttpException.php',
                 'phario\\phive\\httpprogresshandler' => '/shared/http/HttpProgressHandler.php',

--- a/src/commands/help/HelpCommand.php
+++ b/src/commands/help/HelpCommand.php
@@ -9,18 +9,66 @@ class HelpCommand implements Cli\Command {
     /** @var Cli\Output */
     private $output;
 
-    public function __construct(Environment $environment, Cli\Output $output) {
+    /** @var HelpCommandConfig */
+    private $config;
+
+    public function __construct(Environment $environment, Cli\Output $output, HelpCommandConfig $config) {
         $this->environment = $environment;
         $this->output      = $output;
+        $this->config      = $config;
     }
 
     public function execute(): void {
-        $this->output->writeMarkdown(
-            \str_replace(
-                '%phive',
-                $this->environment->getPhiveCommandPath(),
-                \file_get_contents(__DIR__ . '/help.md')
-            ) . "\n\n"
-        );
+        if ($this->config->generic()) {
+            $this->output->writeMarkdown(
+                \str_replace(
+                    '%phive',
+                    $this->environment->getPhiveCommandPath(),
+                    \file_get_contents(__DIR__ . '/help.md')
+                ) . "\n\n"
+            );
+
+            return;
+        }
+
+        $commands = \array_reduce($this->config->getCommandsName(), function (array $statues, string $command) {
+            if ($this->config->hasHelp($command)) {
+                $statues['found'][] = $command;
+            } else {
+                $statues['not-found'][] = $command;
+            }
+
+            return $statues;
+        }, ['found' => [], 'not-found' => []]);
+
+        foreach ($commands['not-found'] as $command) {
+            $this->output->writeWarning(\sprintf('No help found for command "%s"', $command));
+        }
+
+        $usages = [];
+        $help   = [];
+
+        foreach ($commands['found'] as $command) {
+            $usages[] = $this->getHelpPrefix($this->config->getHelpUsage($command));
+            $help[]   = $this->config->getHelpText($command);
+        }
+
+        $this->output->writeMarkdown(\sprintf(
+            \PHP_EOL . '%s' . \PHP_EOL . \PHP_EOL . '%s' . \PHP_EOL . \PHP_EOL . '%s',
+            \implode(\PHP_EOL, $usages),
+            $this->getGlobalOptions(),
+            \implode(\PHP_EOL, $help)
+        ));
+    }
+
+    private function getHelpPrefix(string $command): string {
+        return \sprintf('**Usage**: %s [global-options] %s', $this->environment->getPhiveCommandPath(), $command);
+    }
+
+    private function getGlobalOptions(): string {
+        $help = \file_get_contents(__DIR__ . '/help.md');
+        \preg_match('/^\*\*Global options:\*\*$[^*]+$/m', $help, $match);
+
+        return $match[0] ?? '';
     }
 }

--- a/src/commands/help/HelpCommandConfig.php
+++ b/src/commands/help/HelpCommandConfig.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+class HelpCommandConfig {
+
+    /** @var Cli\Options */
+    private $cliOptions;
+    private $helpList = [];
+
+    public function __construct(Cli\Options $cliOptions) {
+        $this->cliOptions = $cliOptions;
+        $this->createHelpList();
+    }
+
+    public function generic(): bool {
+        if ($this->cliOptions->hasOption('help')) {
+            return false;
+        }
+
+        return $this->cliOptions->getArgumentCount() < 1;
+    }
+
+    /**
+     * @throws Cli\CommandOptionsException
+     *
+     * @return string[]
+     */
+    public function getCommandsName(): array {
+        if ($this->generic()) {
+            return [];
+        }
+        $commands      = $this->cliOptions->getArguments();
+
+        if ($this->cliOptions->hasOption('help')) {
+            $commands[] = $this->cliOptions->getOption('help');
+        }
+
+        return $commands;
+    }
+
+    public function hasHelp(string $command): bool {
+        return \array_key_exists($command, $this->helpList);
+    }
+
+    public function getHelpUsage(string $command): string {
+        if (!$this->hasHelp($command)) {
+            throw new \InvalidArgumentException();
+        }
+
+        return $this->helpList[$command]['usage'];
+    }
+    public function getHelpText(string $command): string {
+        if (!$this->hasHelp($command)) {
+            throw new \InvalidArgumentException();
+        }
+
+        return $this->helpList[$command]['help'];
+    }
+
+    private function createHelpList(): void {
+        $help = \file_get_contents(__DIR__ . '/help.md');
+
+        // Extract command help
+        $helpStartAt = \strpos($help, '**Commands:**');
+        $helpText    = \substr($help, $helpStartAt);
+        \preg_match_all('/^\*\*(?P<command>[\w-]+)(?P<options_arguments> .+)?\*\*$/m', $helpText, $matches, \PREG_SET_ORDER);
+
+        $helps = [];
+
+        for ($index = 0, $indexMax = \count($matches); $index < $indexMax; $index++) {
+            $match                    = $matches[$index];
+            $startAt                  = \strpos($help, $match[0]);
+            $endAt                    = $index === \count($matches) - 1 ? \strlen($help) : \strpos($help, $matches[$index + 1][0]);
+            $helps[$match['command']] = [
+                'usage' => $match['command'] . ($match['options_arguments'] ?? ''),
+                'help'  => \substr($help, $startAt, $endAt - $startAt)
+            ];
+        }
+
+        $this->helpList = $helps;
+    }
+}

--- a/src/commands/help/HelpContext.php
+++ b/src/commands/help/HelpContext.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+namespace PharIo\Phive;
+
+use PharIo\Phive\Cli\GeneralContext;
+
+class HelpContext extends GeneralContext {
+}

--- a/src/commands/help/help.md
+++ b/src/commands/help/help.md
@@ -7,8 +7,10 @@
 
 **Commands:**
 
-**help**
+**help [<command> ...]**
     Show this help output and exit
+    
+    _command_  Get help of a specific command
 
 **version**
     Show release version and exit

--- a/src/shared/cli/Runner.php
+++ b/src/shared/cli/Runner.php
@@ -193,6 +193,11 @@ class Runner {
 
         try {
             $this->showHeader();
+
+            if ($this->request->getOptions()->hasOption('help')) {
+                $this->request->getOptions()->setOption('help', $command);
+                $command = 'help';
+            }
             $this->locator->getCommand($command)->execute();
             $this->showFooter();
         } catch (CommandLocatorException $e) {

--- a/src/shared/http/CurlHttpClient.php
+++ b/src/shared/http/CurlHttpClient.php
@@ -174,7 +174,7 @@ class CurlHttpClient implements HttpClient {
     }
 
     private function parseRateLimitHeaders(): ?RateLimit {
-        $required  = ['Limit', 'Remaining', 'Reset'];
+        $required = ['Limit', 'Remaining', 'Reset'];
         $existing = \array_keys($this->rateLimitHeaders);
 
         if (\count(\array_intersect($required, $existing)) < 3) {

--- a/tests/unit/commands/help/HelpCommandTest.php
+++ b/tests/unit/commands/help/HelpCommandTest.php
@@ -14,9 +14,13 @@ class HelpCommandTest extends TestCase {
             ->method('writeMarkdown')
             ->with($this->stringContains('help'));
 
+        $config = $this->createMock(HelpCommandConfig::class);
+        $config->method('generic')->willReturn(true);
+
         $command = new HelpCommand(
             $this->getEnvironmentMock(),
-            $output
+            $output,
+            $config
         );
 
         $command->execute();


### PR DESCRIPTION
Partially cover #253 

Now we can add argument on the `help` command to have only help of the command pass in argument.
The `--help` global option also do the same

I didn't figured out how to handle the `phive install --help` case in a generic ways, without having the whole cli be entirely rewritten 😕 