### PR TITLE
Ensure Xdebug 3 compatibility

### DIFF
--- a/src/shared/environment/Environment.php
+++ b/src/shared/environment/Environment.php
@@ -124,7 +124,10 @@ abstract class Environment {
         \ini_set('xdebug.scream', 'off');
         \ini_set('xdebug.max_nesting_level', '8192');
         \ini_set('xdebug.show_exception_trace', 'off');
-        xdebug_disable();
+        // since `xdebug_disable` got removed in Xdebug 3 we have to check for its existance
+        if (function_exists('xdebug_disable')) {
+            xdebug_disable();
+        }
     }
 
     private function ensureTimezoneSet(): void {


### PR DESCRIPTION
In version 3 of Xdebug the function `xdebug_disable` got removed
so in order to support version 2 and 3 we have to make sure the
function exists before calling it.