### PR TITLE
Switch the docs to the new GPG key servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ follow these simple steps:
 ```bash
 wget -O phive.phar "https://phar.io/releases/phive.phar"
 wget -O phive.phar.asc "https://phar.io/releases/phive.phar.asc"
-gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x9D8A98B29B2D5D79
 gpg --verify phive.phar.asc phive.phar
 rm phive.phar.asc
 chmod +x phive.phar


### PR DESCRIPTION
pool.sks-keyservers.net is no more. keys.openpgp.org it is now.