### PR TITLE
PHP 8.1: fix deprecation warning

### DIFF
--- a/src/shared/phar/ReleaseCollection.php
+++ b/src/shared/phar/ReleaseCollection.php
@@ -27,7 +27,7 @@ class ReleaseCollection implements Countable, IteratorAggregate {
         return count($this->releases);
     }
 
-    public function getIterator() {
+    public function getIterator(): Traversable {
         return new ArrayIterator($this->releases);
     }
 }


### PR DESCRIPTION
I suspect this may be the underlying cause of #319.

```
Deprecated: Return type of PharIo\Phive\ReleaseCollection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this package has a minimum PHP requirement of PHP 7.3 based on the `composer.json` file, the return type can be safely added.