### PR TITLE
Improve the documentation concerning GPG key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ follow these simple steps:
 ```bash
 wget -O phive.phar "https://phar.io/releases/phive.phar"
 wget -O phive.phar.asc "https://phar.io/releases/phive.phar.asc"
-gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x9D8A98B29B2D5D79
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x6AF725270AB81E04D79442549D8A98B29B2D5D79
 gpg --verify phive.phar.asc phive.phar
 rm phive.phar.asc
 chmod +x phive.phar

--- a/src/commands/help/help.md
+++ b/src/commands/help/help.md
@@ -27,7 +27,8 @@
     _-c, --copy_                   Copy PHAR file instead of using symlink
     _-g, --global_                 Install a copy of the PHAR globally (likely requires root privileges)
         _--temporary_              Do not add entries in phive.xml for installed PHARs
-        _--trust-gpg-keys_         Silently import these keys when required (fingerprint or key id, separated by comma)
+        _--trust-gpg-keys_         Silently import these keys when required (40-digit fingerprint
+                                   or 16-digit long key ID, optionally with the `0x` prefix, separated by comma)
         _--force-accept-unsigned_  Force installation of unsigned phars
 
 **composer**


### PR DESCRIPTION
- use a fingerprint instead of the key ID in the installation intructions
- mention that only long key IDs are supported, but not short ones
- mention the number of digits expected for key IDs and fingerprints