### PR TITLE
Upgrade vfsstream from 1.6.9 to 1.6.10

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -260,16 +260,16 @@
     "packages-dev": [
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.9",
+            "version": "v1.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "2257e326dc3d0f50e55d0a90f71e37899f029718"
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/2257e326dc3d0f50e55d0a90f71e37899f029718",
-                "reference": "2257e326dc3d0f50e55d0a90f71e37899f029718",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/250c0825537d501e327df879fb3d4cd751933b85",
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85",
                 "shasum": ""
             },
             "require": {
@@ -307,7 +307,7 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2021-07-16T08:08:02+00:00"
+            "time": "2021-09-25T08:05:01+00:00"
         }
     ],
     "aliases": [],

--- a/src/shared/JsonData.php
+++ b/src/shared/JsonData.php
@@ -18,7 +18,6 @@ use function is_array;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
-use function sprintf;
 use InvalidArgumentException;
 
 class JsonData {


### PR DESCRIPTION
This version contains fixes for PHP 8.1: https://github.com/bovigo/vfsStream/releases/tag/v1.6.10