### PR TITLE
Upgrade PHPStan to 1.4.2

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpab" version="^1.25" installed="1.26.3" location="./tools/phpab" copy="false"/>
   <phar name="phpunit" version="9" installed="9.5.11" location="./tools/phpunit" copy="false"/>
-  <phar name="phpstan" version="^0.12" installed="0.12.99" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.0" installed="1.4.2" location="./tools/phpstan" copy="false"/>
   <phar name="php-cs-fixer" version="^3.4" installed="3.4.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="psalm" version="4" installed="4.16.1" location="./tools/psalm" copy="false"/>
 </phive>

--- a/src/services/migration/HomePharsXmlMigration.php
+++ b/src/services/migration/HomePharsXmlMigration.php
@@ -26,10 +26,6 @@ class HomePharsXmlMigration implements Migration {
     }
 
     public function canMigrate(): bool {
-        if (!$this->mustMigrate()) {
-            return false;
-        }
-
         return $this->mustMigrate() && !$this->inError();
     }
 

--- a/src/services/phar/PharInstaller.php
+++ b/src/services/phar/PharInstaller.php
@@ -85,12 +85,6 @@ abstract class PharInstaller {
                 (int)$e->getCode(),
                 $e
             );
-        } catch (PharInstallerException $e) {
-            throw new PharInstallerException(
-                sprintf('Directory %s could not be created: %s', $dir->asString(), $e->getMessage()),
-                (int)$e->getCode(),
-                $e
-            );
         }
     }
 

--- a/src/shared/config/AuthXmlConfig.php
+++ b/src/shared/config/AuthXmlConfig.php
@@ -64,9 +64,9 @@ class AuthXmlConfig implements AuthConfig {
 
         switch ($authType) {
             case 'Token':
-                return new TokenAuthentication($domain, $authCredentials);
+                return new TokenAuthentication($authCredentials);
             case 'Bearer':
-                return new BearerAuthentication($domain, $authCredentials);
+                return new BearerAuthentication($authCredentials);
 
             default:
                 throw new AuthException(sprintf('Invalid authentication type for %s', $domain));
@@ -84,11 +84,11 @@ class AuthXmlConfig implements AuthConfig {
             $node->hasAttribute('password') &&
             !empty($node->getAttribute('password'))
         ) {
-            return BasicAuthentication::fromLoginPassword($domain, $username, $node->getAttribute('password'));
+            return BasicAuthentication::fromLoginPassword($username, $node->getAttribute('password'));
         }
 
         if ($node->hasAttribute('credentials') && !empty($node->getAttribute('credentials'))) {
-            return new BasicAuthentication($domain, $node->getAttribute('credentials'));
+            return new BasicAuthentication($node->getAttribute('credentials'));
         }
 
         throw new AuthException(sprintf('Basic authentication data for %s is invalid', $domain));

--- a/src/shared/config/EnvironmentAuthConfig.php
+++ b/src/shared/config/EnvironmentAuthConfig.php
@@ -49,10 +49,10 @@ class EnvironmentAuthConfig implements AuthConfig {
         switch ($domain) {
             // "Token" Authorizations
             case 'api.github.com':
-                return new TokenAuthentication($domain, $token);
+                return new TokenAuthentication($token);
             // "Bearer" Authorizations
             case 'gitlab.com':
-                return new BearerAuthentication($domain, $token);
+                return new BearerAuthentication($token);
 
             default:
                 throw new BadMethodCallException('Unknown authentication');

--- a/src/shared/http/Authentication.php
+++ b/src/shared/http/Authentication.php
@@ -17,12 +17,8 @@ abstract class Authentication {
     /** @var string */
     private $credentials;
 
-    /** @var string */
-    private $domain;
-
-    public function __construct(string $domain, string $credentials) {
+    public function __construct(string $credentials) {
         $this->credentials = $credentials;
-        $this->domain      = $domain;
     }
 
     public function asHttpHeaderString(): string {

--- a/src/shared/http/authentication/BasicAuthentication.php
+++ b/src/shared/http/authentication/BasicAuthentication.php
@@ -13,10 +13,10 @@ namespace PharIo\Phive;
 use function base64_encode;
 
 final class BasicAuthentication extends Authentication {
-    public static function fromLoginPassword(string $domain, string $login, string $password): self {
+    public static function fromLoginPassword(string $login, string $password): self {
         $credentials = base64_encode($login . ':' . $password);
 
-        return new self($domain, $credentials);
+        return new self($credentials);
     }
 
     protected function getType(): string {

--- a/tests/unit/shared/http/AuthenticationTest.php
+++ b/tests/unit/shared/http/AuthenticationTest.php
@@ -21,7 +21,7 @@ class AuthenticationTest extends TestCase {
     public function testCanBeConvertedToString(): void {
         $this->assertEquals(
             'Authorization: Bearer foo',
-            (new BearerAuthentication('example.com', 'foo'))->asHttpHeaderString()
+            (new BearerAuthentication('foo'))->asHttpHeaderString()
         );
     }
 
@@ -29,7 +29,7 @@ class AuthenticationTest extends TestCase {
         // https://tools.ietf.org/html/rfc7617#section-2
         $this->assertEquals(
             'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==',
-            BasicAuthentication::fromLoginPassword('example.com', 'Aladdin', 'open sesame')->asHttpHeaderString()
+            BasicAuthentication::fromLoginPassword('Aladdin', 'open sesame')->asHttpHeaderString()
         );
     }
 }

--- a/tests/unit/shared/http/CurlConfigBuilderTest.php
+++ b/tests/unit/shared/http/CurlConfigBuilderTest.php
@@ -62,7 +62,7 @@ class CurlConfigBuilderTest extends TestCase {
     public function testAddsGitHubAuthToken(): void {
         $this->authConfig->method('getAuthentication')
             ->with('api.github.com')
-            ->willReturn(new TokenAuthentication('api.github.com', 'foo'));
+            ->willReturn(new TokenAuthentication('foo'));
         $this->authConfig->method('hasAuthentication')
             ->with('api.github.com')
             ->willReturn(true);
@@ -75,7 +75,7 @@ class CurlConfigBuilderTest extends TestCase {
     public function testAddsGitLabAuthToken(): void {
         $this->authConfig->method('getAuthentication')
             ->with('gitlab.com')
-            ->willReturn(new BearerAuthentication('gitlab.com', 'foo'));
+            ->willReturn(new BearerAuthentication('foo'));
         $this->authConfig->method('hasAuthentication')
             ->with('gitlab.com')
             ->willReturn(true);

--- a/tests/unit/shared/http/CurlHttpClientTest.php
+++ b/tests/unit/shared/http/CurlHttpClientTest.php
@@ -215,7 +215,7 @@ class CurlHttpClientTest extends TestCase {
 
         $this->curlConfig->method('getAuthentication')
             ->with('example.com')
-            ->willReturn(new TokenAuthentication('example.com', 'foobar'));
+            ->willReturn(new TokenAuthentication('foobar'));
 
         $this->curl->expects($this->once())
             ->method('addHttpHeaders')


### PR DESCRIPTION
I've updated PHPStan to its latest version and fixed the new issues discovered below:
```
# ./tools/phpstan
Note: Using configuration file phpstan.neon.

 223/223 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------
  Line   src/services/migration/HomePharsXmlMigration.php
 ------ --------------------------------------------------
  33     Left side of && is always true.
 ------ --------------------------------------------------

 ------ ------------------------------------------------------------------------------------
  Line   src/services/phar/PharInstaller.php
 ------ ------------------------------------------------------------------------------------
  88     Dead catch - PharIo\Phive\PharInstallerException is never thrown in the try block.
 ------ ------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------
  Line   src/shared/http/Authentication.php
 ------ ----------------------------------------------------------------------------------
  21     Property PharIo\Phive\Authentication::$domain is never read, only written.
         💡 See: https://phpstan.org/developing-extensions/always-read-written-properties
 ------ ----------------------------------------------------------------------------------


 [ERROR] Found 3 errors


```