### PR TITLE
Upgrade Psalm to 4.21.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -4,5 +4,5 @@
   <phar name="phpunit" version="9" installed="9.5.11" location="./tools/phpunit" copy="false"/>
   <phar name="phpstan" version="^1.0" installed="1.4.2" location="./tools/phpstan" copy="false"/>
   <phar name="php-cs-fixer" version="^3.4" installed="3.4.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="psalm" version="4" installed="4.16.1" location="./tools/psalm" copy="false"/>
+  <phar name="psalm" version="4" installed="4.21.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="2"
-    totallyTyped="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -113,6 +113,7 @@ spl_autoload_register(
                 'phario\\phive\\installservice' => '/services/phar/InstallService.php',
                 'phario\\phive\\internalfilemigration' => '/services/migration/InternalFileMigration.php',
                 'phario\\phive\\invalidhashexception' => '/shared/exceptions/InvalidHashException.php',
+                'phario\\phive\\invalidxmlexception' => '/shared/exceptions/InvalidXmlException.php',
                 'phario\\phive\\ioexception' => '/shared/exceptions/IOException.php',
                 'phario\\phive\\jsondata' => '/shared/JsonData.php',
                 'phario\\phive\\keydownloader' => '/services/key/KeyDownloader.php',

--- a/src/services/resolver/PharIoAliasResolver.php
+++ b/src/services/resolver/PharIoAliasResolver.php
@@ -50,11 +50,13 @@ class PharIoAliasResolver extends AbstractRequestedPharResolver {
                     new JsonData($file->getContent())
                 );
             case 'phar.io':
-                $repo = new PharIoRepository(
-                    XmlFile::fromFile($file)
-                );
-
-                return $repo;
+                try {
+                    return new PharIoRepository(
+                        XmlFile::fromFile($file)
+                    );
+                } catch (InvalidXmlException $e) {
+                    break;
+                }
         }
 
         return $this->tryNext($requestedPhar);

--- a/src/shared/XmlFile.php
+++ b/src/shared/XmlFile.php
@@ -35,9 +35,18 @@ class XmlFile {
     /** @var string */
     private $rootElementName;
 
+    /**
+     * @throws InvalidXmlException
+     */
     public static function fromFile(File $file): self {
-        $dom = self::createDomDocument();
-        $dom->loadXML($file->getContent());
+        $dom     = self::createDomDocument();
+        $content = $file->getContent();
+
+        if ($content === '') {
+            throw new InvalidXmlException();
+        }
+
+        $dom->loadXML($content);
 
         $xmlFile = new self(
             $file->getFilename(),

--- a/src/shared/config/PhiveXmlConfig.php
+++ b/src/shared/config/PhiveXmlConfig.php
@@ -156,7 +156,7 @@ abstract class PhiveXmlConfig {
     public function getTargetDirectory(): Directory {
         $node = $this->getTargetDirectoryNode();
 
-        if ($node === null) {
+        if ($node === null || !is_string($node->nodeValue)) {
             throw new ConfigException('Tools directory is not configured in phive.xml');
         }
 

--- a/src/shared/exceptions/InvalidXmlException.php
+++ b/src/shared/exceptions/InvalidXmlException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of Phive.
+ *
+ * Copyright (c) Arne Blankerts <arne@blankerts.de>, Sebastian Heuer <sebastian@phpeople.de> and contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace PharIo\Phive;
+
+class InvalidXmlException extends \Exception implements Exception {
+}

--- a/tests/unit/shared/XmlFileTest.php
+++ b/tests/unit/shared/XmlFileTest.php
@@ -12,6 +12,7 @@ namespace PharIo\Phive;
 
 use org\bovigo\vfs\vfsStream;
 use PharIo\FileSystem\Directory;
+use PharIo\FileSystem\File;
 use PharIo\FileSystem\Filename;
 use PHPUnit\Framework\TestCase;
 
@@ -43,6 +44,22 @@ class XmlFileTest extends TestCase {
         $actual = $file->query('phive:node1', $context);
         $this->assertSame(1, $actual->length);
         $this->assertSame('Node 1 Value', $actual->item(0)->nodeValue);
+    }
+
+    public function testFromFileWithValidXml(): void {
+        $path = __DIR__ . '/fixtures/xmlFile.xml';
+        $file = XmlFile::fromFile(new File(new Filename($path), file_get_contents($path)));
+
+        $actual = $file->query('//phive:node1');
+        $this->assertSame(1, $actual->length);
+        $this->assertSame('Node 1 Value', $actual->item(0)->nodeValue);
+    }
+
+    public function testFromFileWithEmptyContent(): void {
+        $path = __DIR__ . '/fixture/xmlFile.xml';
+
+        $this->expectException(InvalidXmlException::class);
+        $file = XmlFile::fromFile(new File(new Filename($path), ''));
     }
 
     public function testSavesXmlToFile(): void {


### PR DESCRIPTION
After upgrading Psalm I got this message:
```
ERROR: ConfigIssue - psalm.xml:4:5 - Attribute "totallyTyped" is deprecated and is going to be removed in the next major version (see https://psalm.dev/271)
    totallyTyped="false"
```

Once this issue fixed 2 errors were reported:
```
ERROR: ArgumentTypeCoercion - src/shared/XmlFile.php:40:23 - Argument 1 of DOMDocument::loadXML expects non-empty-string, parent type string provided (see https://psalm.dev/193)
        $dom->loadXML($file->getContent());


ERROR: PossiblyNullArgument - src/shared/config/PhiveXmlConfig.php:163:30 - Argument 1 of PharIo\FileSystem\Directory::__construct cannot be null, possibly null value provided (see https://psalm.dev/078)
        return new Directory($node->nodeValue);
```