### PR TITLE
Fix: Avoid using Docker to set up environment

### DIFF
--- a/.github/actions/phive-ant/Dockerfile
+++ b/.github/actions/phive-ant/Dockerfile
@@ -1,6 +1,0 @@
-FROM debian:buster
-
-RUN apt update \
-    && apt-get install -y --no-install-recommends ant php-cli php-dom php-curl php-mbstring wget gpg dirmngr gpg-agent
-
-ENTRYPOINT ["ant"]

--- a/.github/actions/phive-ant/action.yml
+++ b/.github/actions/phive-ant/action.yml
@@ -1,5 +1,0 @@
-name: 'Phive ant'
-description: 'Ant wrapper for phive in github actions'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,42 +8,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: composer
-        uses: docker://composer
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          args: install --no-interaction --prefer-dist --optimize-autoloader
+          php-version: 7.4
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: composer
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: phive
-        uses: './.github/actions/phive-ant'
-        with:
-          args: 'getphive'
+        run: ant getphive
 
       - name: phive install
-        uses: './.github/actions/phive-ant'
-        env:
-          phive.bin: "/phive.phar"
-        with:
-          args: -Dphive.bin=./phive.phar install-tools
+        run: ant -Dphive.bin=./phive.phar install-tools
 
       - name: php-cs-fixer
-        uses: './.github/actions/phive-ant'
-        env:
-          phive.bin: "/phive.phar"
-        with:
-          args: -Dphive.bin=./phive.phar php-cs-fixer
+        run: ant -Dphive.bin=./phive.phar php-cs-fixer
 
       - name: phpstan
-        uses: './.github/actions/phive-ant'
-        env:
-          phive.bin: "/phive.phar"
-        with:
-          args: -Dphive.bin=./phive.phar phpstan
+        run: ant -Dphive.bin=./phive.phar phpstan
 
       - name: psalm
-        uses: './.github/actions/phive-ant'
-        env:
-          phive.bin: "/phive.phar"
-        with:
-          args: -Dphive.bin=./phive.phar psalm
+        run: ant -Dphive.bin=./phive.phar psalm


### PR DESCRIPTION
This pull request

- [x] avoids using Docker to set up an environment on GitHub Actions