### PR TITLE
Fix: Use `actions/checkout@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This pull request

- [x] uses `actions/checkout@v2`

💁‍♂️ The default branch is now called `main`, and `master` is quite behind. Using `v2`, as in the other workflows, makes more sense, too.