### PR TITLE
Fix array access in gitlab repo

### DIFF
--- a/src/shared/repository/GitlabRepository.php
+++ b/src/shared/repository/GitlabRepository.php
@@ -30,7 +30,7 @@ class GitlabRepository implements SourceRepository {
 
         foreach ($this->jsonData->getParsed() as $entry) {
             try {
-                $version = new Version($entry->tag_name);
+                $version = new Version($entry['tag_name']);
             } catch (InvalidVersionException $exception) {
                 // we silently ignore invalid version identifiers for now as they are
                 // likely to be an arbitrary tag that erroneously got promoted to release
@@ -39,9 +39,9 @@ class GitlabRepository implements SourceRepository {
             $pharUrl      = null;
             $signatureUrl = null;
 
-            foreach ($entry->assets->links as $asset) {
-                $assetName = $asset->name;
-                $url       = $asset->url;
+            foreach ($entry['assets']['links'] as $asset) {
+                $assetName = $asset['name'];
+                $url       = $asset['url'];
 
                 if (substr($assetName, -5, 5) === '.phar') {
                     $pharUrl = new PharUrl($url);


### PR DESCRIPTION
I just added a custom repositories.xml to my project with a link to our gitlab instance. The download of the phar didn't work because the parsed JSON returns an array and not an object.