### PR TITLE
Write XML files to temporary file and rename instead of directly writing to files

### DIFF
--- a/src/shared/XmlFile.php
+++ b/src/shared/XmlFile.php
@@ -18,6 +18,8 @@ use DOMXPath;
 use PharIo\FileSystem\Directory;
 use PharIo\FileSystem\File;
 use PharIo\FileSystem\Filename;
+use function rename;
+use function uniqid;
 
 class XmlFile {
     /** @var null|DOMDocument */
@@ -82,7 +84,10 @@ class XmlFile {
 
     public function save(): void {
         $this->getDirectory()->ensureExists();
-        $this->getDom()->save($this->filename->asString());
+        $targetFilename = $this->filename->asString();
+        $temporaryFilename = $targetFilename . '.' . uniqid('tmp', true);
+        $this->getDom()->save($temporaryFilename);
+        rename($temporaryFilename, $targetFilename);
     }
 
     public function getDirectory(): Directory {


### PR DESCRIPTION
This will prevent `DOMDocument#save` having race conditions with itself.
This should be a fix for #368

I'll try to create a test script with `pcntl_fork` to proof that this might fix the issue tho I am not 100% sure.