### PR TITLE
Fix tests with PHP 8.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -260,16 +260,16 @@
     "packages-dev": [
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.10",
+            "version": "v1.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "250c0825537d501e327df879fb3d4cd751933b85"
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/250c0825537d501e327df879fb3d4cd751933b85",
-                "reference": "250c0825537d501e327df879fb3d4cd751933b85",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
                 "shasum": ""
             },
             "require": {
@@ -307,7 +307,7 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2021-09-25T08:05:01+00:00"
+            "time": "2022-02-23T02:02:42+00:00"
         }
     ],
     "aliases": [],
@@ -323,5 +323,5 @@
         "ext-xml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/tests/unit/TestStreamWrapper.php
+++ b/tests/unit/TestStreamWrapper.php
@@ -36,6 +36,8 @@ class TestStreamWrapper {
 
     public static $map = [];
 
+    public $context;
+
     protected $_protocol;
 
     /** @var string */


### PR DESCRIPTION
- Upgrade vfsStream from 1.6.10 to [1.6.11](https://github.com/bovigo/vfsStream/releases/tag/v1.6.11) to support PHP 8.2
- Add context property in TestStreamWrapper (the same way it was done in [vfsStream](https://github.com/bovigo/vfsStream/pull/270))