### PR TITLE
Enhancement: Link `/repo/` to `/github/workspace/`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,7 @@ RUN chmod +x /usr/local/bin/phive
 RUN mkdir /repo
 RUN mkdir /phive
 RUN ln -sf /usr/sbin/busybox /bin/sh
+RUN mkdir /github && ln -s /repo /github/workspace
 
 ENV PHIVE_HOME=/phive
 ENV HOME=/phive


### PR DESCRIPTION
This pull request

- [x] creates a `/github/` directory and a symbolic link from `/repo/` to `/github/workspace/`

💁‍♂️ I am unsure how to mount a volume when using a Docker image in a GitHub Actions step. However, as you can see in https://github.com/ergebnis/playground/actions/runs/4053829531/jobs/6974917526#step:10:13, GitHub mounts the GitHub workspace directory, e.g., `/home/runner/work/playground/playground` to `/github/workspace`, so by creating a symbolic link from `/github/workspace` to `/repo` should make the failing workflow referenced above pass.

What do you think?