### PR TITLE
Fix: Keep values sorted

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         operating-system:
+          - macOS-latest
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
         php-versions:
           - '7.3'
           - '7.4'


### PR DESCRIPTION
This pull request

- [x] keeps the values in the `operating-system` matrix sorted

💁‍♂️ The order does not matter, so why not keep them sorted?