### PR TITLE
Fix: Do not bother manually assembling job names

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -23,7 +23,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
-    name: Run install on [${{ matrix.php-versions }} | ${{ matrix.operating-system }}]
+    name: Run install
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache environment

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
-    name: Test on [${{ matrix.php-versions }} | ${{ matrix.operating-system }}]
+    name: Test
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache environment


### PR DESCRIPTION
This pull request

- [x] stops manually assembling job names

## Before

![CleanShot 2023-01-31 at 20 04 51@2x](https://user-images.githubusercontent.com/605483/215857737-667511aa-0f19-4a09-8b89-06c1849a77cc.png)

## After

![CleanShot 2023-01-31 at 20 12 04@2x](https://user-images.githubusercontent.com/605483/215859564-e7a12343-69ad-4ad6-9904-477dd9de683b.png)
