### PR TITLE
Sort the list of aliases alphabetically

### DIFF
--- a/src/commands/list/ListCommand.php
+++ b/src/commands/list/ListCommand.php
@@ -11,6 +11,7 @@
 namespace PharIo\Phive;
 
 use function count;
+use function sort;
 
 class ListCommand implements Cli\Command {
     /** @var SourcesList */
@@ -41,6 +42,8 @@ class ListCommand implements Cli\Command {
     }
 
     private function printAliases(array $aliases): void {
+        sort($aliases);
+
         foreach ($aliases as $aliasName) {
             $this->output->writeText("* {$aliasName}\n");
         }

--- a/tests/unit/commands/list/ListCommandTest.php
+++ b/tests/unit/commands/list/ListCommandTest.php
@@ -35,15 +35,15 @@ class ListCommandTest extends TestCase {
 
         $output->expects($this->at(3))
             ->method('writeText')
-            ->with($this->stringContains('phpunit'));
+            ->with($this->stringContains('phpab'));
 
         $output->expects($this->at(4))
             ->method('writeText')
-            ->with($this->stringContains('phpab'));
+            ->with($this->stringContains('phploc'));
 
         $output->expects($this->at(5))
             ->method('writeText')
-            ->with($this->stringContains('phploc'));
+            ->with($this->stringContains('phpunit'));
 
         $command = new ListCommand($sourcesList, $localSources, $output);
         $command->execute();


### PR DESCRIPTION
This will make it easier to find a specific alias in the list, and groups related aliases together.

Fixes https://github.com/phar-io/phive/issues/408.