### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,7 +31,7 @@ class Factory {
     /** @var null|PharRegistry */
     private $registry;
 
-    public function __construct(Cli\Request $request, PhiveVersion $version = null) {
+    public function __construct(Cli\Request $request, ?PhiveVersion $version = null) {
         $this->request = $request;
         $this->version = $version;
     }

--- a/src/commands/skel/SkelCommand.php
+++ b/src/commands/skel/SkelCommand.php
@@ -31,7 +31,7 @@ class SkelCommand implements Cli\Command {
     /** @var Output */
     private $output;
 
-    public function __construct(SkelCommandConfig $config, Cli\Output $output, PhiveVersion $version, DateTimeImmutable $now = null) {
+    public function __construct(SkelCommandConfig $config, Cli\Output $output, PhiveVersion $version, ?DateTimeImmutable $now = null) {
         $this->config  = $config;
         $this->version = $version;
 

--- a/src/shared/XmlFile.php
+++ b/src/shared/XmlFile.php
@@ -68,7 +68,7 @@ class XmlFile {
         return $this->getDom()->createElementNS($this->namespace, $name, $text);
     }
 
-    public function query(string $xpath, DOMNode $ctx = null): DOMNodeList {
+    public function query(string $xpath, ?DOMNode $ctx = null): DOMNodeList {
         if ($ctx === null) {
             $ctx = $this->getDom()->documentElement;
         }

--- a/src/shared/cli/Runner.php
+++ b/src/shared/cli/Runner.php
@@ -137,7 +137,7 @@ class Runner {
     /**
      * @param array<int, array<string, mixed>> $trace
      */
-    private function showErrorWithTrace(string $error, string $file, int $line, array $trace = null): void {
+    private function showErrorWithTrace(string $error, string $file, int $line, ?array $trace = null): void {
         $baseLen = strlen(dirname(__DIR__, 3) . '') + 1;
 
         $message   = [$error];

--- a/src/shared/config/Config.php
+++ b/src/shared/config/Config.php
@@ -33,7 +33,7 @@ class Config {
     public function __construct(
         Environment $environment,
         Options $cliOptions,
-        DateTimeImmutable $now = null
+        ?DateTimeImmutable $now = null
     ) {
         $this->environment = $environment;
         $this->cliOptions  = $cliOptions;

--- a/src/shared/http/CurlHttpClient.php
+++ b/src/shared/http/CurlHttpClient.php
@@ -55,7 +55,7 @@ class CurlHttpClient implements HttpClient {
     /**
      * @throws HttpException
      */
-    public function head(Url $url, ETag $etag = null): HttpResponse {
+    public function head(Url $url, ?ETag $etag = null): HttpResponse {
         $this->url  = $url;
         $this->etag = $etag;
 
@@ -69,7 +69,7 @@ class CurlHttpClient implements HttpClient {
     /**
      * @throws HttpException
      */
-    public function get(Url $url, ETag $etag = null): HttpResponse {
+    public function get(Url $url, ?ETag $etag = null): HttpResponse {
         $this->url  = $url;
         $this->etag = $etag;
 

--- a/src/shared/http/HttpClient.php
+++ b/src/shared/http/HttpClient.php
@@ -11,7 +11,7 @@
 namespace PharIo\Phive;
 
 interface HttpClient {
-    public function get(Url $url, ETag $etag = null): HttpResponse;
+    public function get(Url $url, ?ETag $etag = null): HttpResponse;
 
-    public function head(Url $url, ETag $etag = null): HttpResponse;
+    public function head(Url $url, ?ETag $etag = null): HttpResponse;
 }

--- a/src/shared/http/HttpResponse.php
+++ b/src/shared/http/HttpResponse.php
@@ -23,7 +23,7 @@ class HttpResponse {
     /** @var null|RateLimit */
     private $rateLimit;
 
-    public function __construct(int $httpCode, string $responseBody, ETag $etag = null, RateLimit $rateLimit = null) {
+    public function __construct(int $httpCode, string $responseBody, ?ETag $etag = null, ?RateLimit $rateLimit = null) {
         $this->responseBody = $responseBody;
         $this->httpCode     = $httpCode;
         $this->etag         = $etag;

--- a/src/shared/http/RetryingHttpClient.php
+++ b/src/shared/http/RetryingHttpClient.php
@@ -46,19 +46,19 @@ class RetryingHttpClient implements HttpClient {
         $this->output   = $output;
     }
 
-    public function head(Url $url, ETag $etag = null): HttpResponse {
+    public function head(Url $url, ?ETag $etag = null): HttpResponse {
         $this->triesPerformed = 0;
 
         return $this->doTry('head', $url, $etag);
     }
 
-    public function get(Url $url, ETag $etag = null): HttpResponse {
+    public function get(Url $url, ?ETag $etag = null): HttpResponse {
         $this->triesPerformed = 0;
 
         return $this->doTry('get', $url, $etag);
     }
 
-    private function doTry(string $method, Url $url, ETag $etag = null): HttpResponse {
+    private function doTry(string $method, Url $url, ?ETag $etag = null): HttpResponse {
         try {
             $this->triesPerformed++;
 

--- a/src/shared/http/RingdownCurlHttpClient.php
+++ b/src/shared/http/RingdownCurlHttpClient.php
@@ -40,11 +40,11 @@ class RingdownCurlHttpClient implements HttpClient {
         $this->output = $output;
     }
 
-    public function get(Url $url, ETag $etag = null): HttpResponse {
+    public function get(Url $url, ?ETag $etag = null): HttpResponse {
         return $this->execWrapper('get', $url, $etag);
     }
 
-    public function head(Url $url, ETag $etag = null): HttpResponse {
+    public function head(Url $url, ?ETag $etag = null): HttpResponse {
         return $this->execWrapper('head', $url, $etag);
     }
 

--- a/src/shared/phar/ConfiguredPhar.php
+++ b/src/shared/phar/ConfiguredPhar.php
@@ -36,9 +36,9 @@ class ConfiguredPhar {
     public function __construct(
         string $name,
         VersionConstraint $versionConstraint,
-        Version $installedVersion = null,
-        Filename $location = null,
-        PharUrl $url = null,
+        ?Version $installedVersion = null,
+        ?Filename $location = null,
+        ?PharUrl $url = null,
         bool $copy = false
     ) {
         $this->name              = $name;

--- a/src/shared/phar/Phar.php
+++ b/src/shared/phar/Phar.php
@@ -30,7 +30,7 @@ class Phar {
     /** @var null|string */
     private $signatureFingerprint;
 
-    public function __construct(string $name, Version $version, File $file, string $signatureFingerprint = null) {
+    public function __construct(string $name, Version $version, File $file, ?string $signatureFingerprint = null) {
         $this->name                 = $name;
         $this->file                 = $file;
         $this->version              = $version;

--- a/src/shared/phar/RequestedPhar.php
+++ b/src/shared/phar/RequestedPhar.php
@@ -34,7 +34,7 @@ class RequestedPhar {
         PharIdentifier $identifier,
         VersionConstraint $versionConstraint,
         VersionConstraint $lockedVersion,
-        Filename $location = null,
+        ?Filename $location = null,
         bool $makeCopy = false
     ) {
         $this->identifier        = $identifier;

--- a/src/shared/phar/SupportedRelease.php
+++ b/src/shared/phar/SupportedRelease.php
@@ -28,7 +28,7 @@ class SupportedRelease implements Release {
     /** @var null|Url */
     private $signatureUrl;
 
-    public function __construct(string $name, Version $version, PharUrl $url, Url $signatureUrl = null, Hash $expectedHash = null) {
+    public function __construct(string $name, Version $version, PharUrl $url, ?Url $signatureUrl = null, ?Hash $expectedHash = null) {
         $this->name         = $name;
         $this->version      = $version;
         $this->url          = $url;

--- a/src/shared/phar/UsedPhar.php
+++ b/src/shared/phar/UsedPhar.php
@@ -22,7 +22,7 @@ class UsedPhar extends Phar {
         Version $version,
         File $file,
         array $usages,
-        string $signatureFingerprint = null
+        ?string $signatureFingerprint = null
     ) {
         parent::__construct($name, $version, $file, $signatureFingerprint);
         $this->usages = $usages;

--- a/src/shared/repository/UrlRepository.php
+++ b/src/shared/repository/UrlRepository.php
@@ -20,7 +20,7 @@ class UrlRepository implements SourceRepository {
     /**
      * UrlRepository constructor.
      */
-    public function __construct(Url $url = null, Url $sigUrl = null) {
+    public function __construct(?Url $url = null, ?Url $sigUrl = null) {
         $this->url    = $url;
         $this->sigUrl = $sigUrl;
     }

--- a/tests/regression/RegressionTestCase.php
+++ b/tests/regression/RegressionTestCase.php
@@ -80,7 +80,7 @@ class RegressionTestCase extends TestCase {
      * @param string $version
      * @param string $filename
      */
-    protected function addPharToRegistry($name, $version, $filename, Filename $usage = null): void {
+    protected function addPharToRegistry($name, $version, $filename, ?Filename $usage = null): void {
         $phar = new Phar($name, new Version($version), new File(new Filename($filename), 'foo'));
         $this->getPharRegistry()->addPhar($phar);
 


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)