### PR TITLE
Add dependabot config for GH Actions runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Actions:"


### PR DESCRIPTION
I noticed the `actions/checkout` action runner is out of date (still on v3 which uses Node 16 for which support will be stopped on GHA soonish).

So I figured adding a dependabot config to make those type of updates would save me from making them manually ;-)