### PR TITLE
Remove pgp.mit.edu as keyserver

### DIFF
--- a/conf/pgp-keyservers.php
+++ b/conf/pgp-keyservers.php
@@ -3,5 +3,4 @@
 return [
     'keys.openpgp.org',
     'keyserver.ubuntu.com',
-    'pgp.mit.edu'
 ];


### PR DESCRIPTION
This PR removes the "pgp.mit.edu" as keyserver.
Related to this, there is already an issue in another Github Repository (https://github.com/saltstack/salt/issues/63806), and as i understand this SKS is down shouldn't be used anymore.