### PR TITLE
Add extension .phar to installed tools

### DIFF
--- a/src/commands/help/help.md
+++ b/src/commands/help/help.md
@@ -25,6 +25,8 @@
     _-t, --target_                 Set custom target directory for the PHAR
 
     _-c, --copy_                   Copy PHAR file instead of using symlink
+    _-e, --extension_              Add extension ".phar" to installed file. It can be usefull for autocompletion by IDE
+                                   in configuration files of installed tools.
     _-g, --global_                 Install a copy of the PHAR globally (likely requires root privileges)
         _--temporary_              Do not add entries in phive.xml for installed PHARs
         _--trust-gpg-keys_         Silently import these keys when required (40-digit fingerprint

--- a/src/commands/install/InstallCommand.php
+++ b/src/commands/install/InstallCommand.php
@@ -63,6 +63,14 @@ class InstallCommand implements Cli\Command {
         return $this->config;
     }
 
+    private function normaliseName(string $pharName): string {
+        if ($this->config->withExtension() && '.phar' !== substr($pharName, -5)) {
+            $pharName .= '.phar';
+        }
+
+        return $pharName;
+    }
+
     private function resolveToRelease(RequestedPhar $requestedPhar): SupportedRelease {
         $repository = $this->pharResolver->resolve($requestedPhar);
         $releases   = $repository->getReleasesByRequestedPhar($requestedPhar);
@@ -80,6 +88,6 @@ class InstallCommand implements Cli\Command {
             return $requestedPhar->getLocation();
         }
 
-        return $destination->file($pharName);
+        return $destination->file($this->normaliseName($pharName));
     }
 }

--- a/src/commands/install/InstallCommandConfig.php
+++ b/src/commands/install/InstallCommandConfig.php
@@ -82,6 +82,10 @@ class InstallCommandConfig {
         return $this->cliOptions->hasOption('force-accept-unsigned');
     }
 
+    public function withExtension(): bool {
+        return $this->cliOptions->hasOption('extension');
+    }
+
     /**
      * @throws ConfiguredPharException
      *

--- a/src/commands/install/InstallContext.php
+++ b/src/commands/install/InstallContext.php
@@ -22,6 +22,7 @@ class InstallContext extends GeneralContext {
         return [
             'target'                => 't',
             'copy'                  => 'c',
+            'extension'             => 'e',
             'global'                => 'g',
             'temporary'             => false,
             'trust-gpg-keys'        => false,

--- a/tests/unit/commands/install/InstallCommandConfigTest.php
+++ b/tests/unit/commands/install/InstallCommandConfigTest.php
@@ -148,6 +148,28 @@ class InstallCommandConfigTest extends TestCase {
         $this->assertSame($switch, $config->doNotAddToPhiveXml());
     }
 
+    /**
+     * @dataProvider boolProvider
+     *
+     * @param bool $switch
+     */
+    public function testWithExtension($switch): void {
+        $options = $this->getOptionsMock();
+        $options->expects($this->once())
+            ->method('hasOption')
+            ->with('extension')
+            ->willReturn($switch);
+
+        $config = new InstallCommandConfig(
+            $options,
+            $this->getPhiveXmlConfigMock(),
+            $this->getEnvironmentMock(),
+            $this->getTargetDirectoryLocatorMock()
+        );
+
+        $this->assertSame($switch, $config->withExtension());
+    }
+
     public function testConvertsRequestedPharAliasToLowercase(): void {
         $options = $this->getOptionsMock();
         $options->expects($this->any())

--- a/tests/unit/commands/install/InstallCommandTest.php
+++ b/tests/unit/commands/install/InstallCommandTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of Phive.
+ *
+ * Copyright (c) Arne Blankerts <arne@blankerts.de>, Sebastian Heuer <sebastian@phpeople.de> and contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace PharIo\Phive;
+
+use PharIo\FileSystem\Directory;
+use PharIo\Version\AnyVersionConstraint;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PharIo\Phive\InstallCommandConfig
+ */
+class InstallCommandTest extends TestCase
+{
+    use ScalarTestDataProvider;
+
+    /**
+     * @dataProvider boolProvider
+     *
+     * @param bool $switch
+     */
+    public function testAddingOfExtension($switch): void
+    {
+        $pharName = $expectedPharName = 'some-path';
+        if ($switch) {
+            $expectedPharName .= '.phar';
+        }
+
+        $directory = $this->createMock(Directory::class);
+        $directory
+            ->expects($this->once())
+            ->method('file')
+            ->with($expectedPharName);
+
+        $requestedPhars = [
+            new RequestedPhar(
+                new PharAlias($pharName),
+                new AnyVersionConstraint(),
+                new AnyVersionConstraint(),
+                null,
+                true
+            ),
+        ];
+
+        $config = $this->createMock(InstallCommandConfig::class);
+        $config
+            ->method('getTargetDirectory')
+            ->willReturn($directory);
+
+        $config
+            ->method('getRequestedPhars')
+            ->willReturn($requestedPhars);
+
+        $config
+            ->method('withExtension')
+            ->willReturn($switch);
+
+        $installService = $this->createMock(InstallService::class);
+        $sourceRepository = $this->createMock(SourceRepository::class);
+
+        $pharResolver = $this->createMock(RequestedPharResolverService::class);
+        $pharResolver
+            ->method('resolve')
+            ->willReturn($sourceRepository);
+
+        $url = $this->createMock(PharUrl::class);
+        $url
+            ->method('getPharName')
+            ->willReturn($pharName);
+
+        $release = $this->createMock(SupportedRelease::class);
+        $release
+            ->method('getUrl')
+            ->willReturn($url);
+
+        $selector = $this->createMock(ReleaseSelector::class);
+        $selector
+            ->method('select')
+            ->willReturn($release);
+
+        $command = new InstallCommand($config, $installService, $pharResolver, $selector);
+        $command->execute();
+    }
+}

--- a/tests/unit/commands/install/InstallContextTest.php
+++ b/tests/unit/commands/install/InstallContextTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of Phive.
+ *
+ * Copyright (c) Arne Blankerts <arne@blankerts.de>, Sebastian Heuer <sebastian@phpeople.de> and contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace PharIo\Phive;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PharIo\Phive\InstallContext
+ */
+class InstallContextTest extends TestCase {
+    /**
+     * @dataProvider knownOptionCharProvider
+     *
+     * @param string $optionChar
+     */
+    public function testHasOptionForChar($optionChar): void
+    {
+        $context = new InstallContext();
+        self::assertTrue($context->hasOptionForChar($optionChar));
+    }
+
+    /**
+     * @dataProvider knowsOptionProvider
+     *
+     * @param string $option
+     */
+    public function testKnowsOption($option): void
+    {
+        $context = new InstallContext();
+        self::assertTrue($context->knowsOption($option));
+    }
+
+    public function knowsOptionProvider(): array {
+        return [
+            ['extension'],
+        ];
+    }
+
+    public function knownOptionCharProvider(): array {
+        return [
+            ['e'],
+        ];
+    }
+}


### PR DESCRIPTION
PHPStorm don't understand content of PHAR file and cannot autocomplete when tool installed via link and without extension. Currently, we have to do it manually. So, this update should help to solve this issue.


![image](https://github.com/user-attachments/assets/0a26c177-8423-4a91-a4b5-5066fc110f2f)
